### PR TITLE
Run github actions on multiple python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,10 @@ on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+    name: 'Ubuntu, python ${{ matrix.python-version }}'
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -13,7 +17,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/wrdcld/rectangle.py
+++ b/wrdcld/rectangle.py
@@ -317,7 +317,7 @@ def _make_new_rectangles(
 ):
 
     new_rectangles = []
-    for left_ind, right_ind in zip(left_inds, right_inds, strict=True):
+    for left_ind, right_ind in zip(left_inds, right_inds):
         # if the rectangle is too small
         if right_ind - left_ind < MIN_RECTANGLE_SIDE_LENGTH:
             continue


### PR DESCRIPTION
Fixes #24 

Removed strict=True since we don't seem to be doing anything if the lists happen to be of different length (other than crash).

When 3.13 comes out it might be time for 3.9 to be removed from the list.

Only running on ubuntu for now, we can consider multiple OSs later.